### PR TITLE
Added github standard Haskell gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+dist
+cabal-dev
+*.o
+*.hi
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
+.stack-work/


### PR DESCRIPTION
Makes working with git a lot easier. And this is a fully configured gitignore as usually used by GutHub for Haskell projects.
